### PR TITLE
v1.2.1

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 ### v1.2.1
 
  - perform installation of Tailscale different between Proxmox versions
+ - attempt initial ping reachability tests a few times
  - make `curl` a dependency
  - remove `run_tailscale_cert_services` function (no longer needed)
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,7 +5,7 @@
  - perform installation of Tailscale between different Proxmox versions
  - attempt initial ping reachability tests a few times
  - make `curl` a dependency
- - remove `run_tailscale_cert_services` function (no longer needed)
+ - remove `run_tailscale_cert_services` function (removed in v1.2.0)
 
 ---
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,10 +15,10 @@ This version changes a core piece of architecture for tailmox - mainly that `tai
 
 Because of this change, [tailscale-cert-services](https://github.com/willjasen/tailscale-cert-services) is no longer needed.
 
-- switch to using `tailscale serve` to handle HTTP/API communication
-- check that TCP 443 is available on all tailmox hosts (available via `tailscale serve`)
-- ensure that the ping check tries a few times over a few seconds
-- clean up unneccessary console output/logging
+ - switch to using `tailscale serve` to handle HTTP/API communication
+ - check that TCP 443 is available on all tailmox hosts (available via `tailscale serve`)
+ - ensure that the ping check tries a few times over a few seconds
+ - clean up unneccessary console output/logging
 
 ---
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,13 @@
 # VERSIONS.md
 
+### v1.2.1
+
+ - perform installation of Tailscale different between Proxmox versions
+ - make `curl` a dependency
+ - remove `run_tailscale_cert_services` function (no longer needed)
+
+---
+
 ### v1.2.0
 
 This version changes a core piece of architecture for tailmox - mainly that `tailscale serve` is now used as a reverse proxy for the pveproxy service, rather than managing the Tailscale certificate manually. This allows communication between hosts on port 443, meaning that URLs can now exclude the ":8006" port specification at the end. It also decouples Proxmox from Tailscale a bit, insomuch that binding the Tailscale certificate directly to pveproxy is no longer necessary.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,7 +2,7 @@
 
 ### v1.2.1
 
- - perform installation of Tailscale different between Proxmox versions
+ - perform installation of Tailscale between different Proxmox versions
  - attempt initial ping reachability tests a few times
  - make `curl` a dependency
  - remove `run_tailscale_cert_services` function (no longer needed)

--- a/tailmox.sh
+++ b/tailmox.sh
@@ -153,21 +153,6 @@ function start_tailscale() {
     log_echo "${GREEN}This host's Tailscale MagicDNS name: $TAILSCALE_DNS_NAME ${RESET}"
 }
 
-# Run Tailscale certificate services
-function run_tailscale_cert_services() {
-    if [ ! -d "/opt/tailscale-cert-services" ]; then
-        log_echo "${YELLOW}Tailscale certificate services not found. Cloning repository...${RESET}"
-        git clone --quiet https://github.com/willjasen/tailscale-cert-services /opt/tailscale-cert-services;
-    else
-        log_echo "${GREEN}Tailscale certificate services already cloned.${RESET}"
-    fi
-    cd /opt/tailscale-cert-services;
-    VERSION="v1.1.1";
-    git -c advice.detachedHead=false checkout tags/${VERSION} --quiet
-    ./proxmox-cert.sh;
-    cd /opt/tailmox;
-}
-
 # Check if all peers with the "tailmox" tag are online
 function check_all_peers_online() {
     log_echo "${YELLOW}Checking if all tailmox peers are online...${RESET}"

--- a/tailmox.sh
+++ b/tailmox.sh
@@ -95,7 +95,7 @@ function check_script_directory() {
 function install_dependencies() {
     log_echo "${YELLOW}Checking for required dependencies...${RESET}"
 
-    local dependencies=(jq expect git)
+    local dependencies=(curl expect git jq)
     for dep in "${dependencies[@]}"; do
         if ! command -v "$dep" &>/dev/null; then
             log_echo "${YELLOW}$dep not found. Installing...${RESET}"
@@ -117,14 +117,12 @@ function install_tailscale() {
         
         if [[ "$pve_version" == "8" ]]; then
             log_echo "${YELLOW}Detected Proxmox v8. Proceeding with Tailscale installation for Proxmox v8...${RESET}"
-            apt install curl -y
             curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
             curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list
             apt update
             apt install tailscale -y
         elif [[ "$pve_version" == "9" ]]; then
             log_echo "${YELLOW}Detected Proxmox v9. Proceeding with Tailscale installation for Proxmox v9...${RESET}"
-            apt install curl -y
             curl -fsSL https://tailscale.com/install.sh | sh
         else
             log_echo "${RED}Unsupported Proxmox version: $pve_version. Exiting...${RESET}"


### PR DESCRIPTION
 - perform installation of Tailscale between different Proxmox versions
 - attempt initial ping reachability tests a few times
 - make `curl` a dependency
 - remove `run_tailscale_cert_services` function (removed in v1.2.0)